### PR TITLE
Modify services tests and related services

### DIFF
--- a/server/src/models/guardians.ts
+++ b/server/src/models/guardians.ts
@@ -7,7 +7,7 @@ const guardianSchema = new mongoose.Schema<IGuardian>({
   dateOfBirth: { type: Date, required: true },
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
-  childId: { type: String, required: true }
+  childId: { type: String, required: false },
 });
 
 guardianSchema.set("toJSON", {

--- a/server/src/routes/guardian_router.ts
+++ b/server/src/routes/guardian_router.ts
@@ -1,43 +1,16 @@
 import express from "express";
-import Guardian from "../models/guardians";
+import {
+  create_guardian,
+  get_all_guardians,
+  get_guardian_by_id,
+} from "../services/guardian_service";
 
 const router = express.Router();
 
-router.get("/", (_req, res) => {
-  Guardian.find({}).then((result) => {
-    res.json(result);
-  });
-});
+router.get("/", get_all_guardians);
 
-router.get("/:id", (req, res) => {
-  return Guardian.findById(req.params.id).then((guardian) => {
-    return res.json(guardian);
-  });
-});
+router.get("/:id", get_guardian_by_id);
 
-router.post("/", (req, res) => {
-  const body = req.body;
-
-  if (!body) {
-    return res.status(400).json({ error: "content missing" });
-  }
-
-  const guardian = new Guardian({
-    name: body.name,
-    dateOfBirth: new Date(body.dateOfBirth),
-    email: body.email,
-    password: body.password,
-    childId: body.childId
-  });
-
-  let error = guardian.validateSync();
-  if (error) {
-    return res.status(400).json(error);
-  }
-
-  return guardian.save().then((savedGuardian) => {
-    return res.json(savedGuardian);
-  });
-});
+router.post("/", create_guardian);
 
 export default router;

--- a/server/src/routes/teenager_router.ts
+++ b/server/src/routes/teenager_router.ts
@@ -1,67 +1,19 @@
 import express from "express";
-import Teenager from "../models/teenagers";
+import {
+  create_teenager,
+  get_all_teenagers,
+  get_teenager_by_id,
+  update_teenager_team,
+} from "../services/teenager_service";
 
 const router = express.Router();
 
-router.get("/", (_req, res) => {
-  Teenager.find({}).then((result) => {
-    res.json(result);
-  });
-});
+router.get("/", get_all_teenagers);
 
-router.get("/:id", (req, res) => {
-  return Teenager.findById(req.params.id).then((teenager) => {
-    return res.json(teenager);
-  });
-});
+router.get("/:id", get_teenager_by_id);
 
-router.patch("/:id", async (req, res) => {
-  const { teamId } = req.body;
+router.patch("/:id", update_teenager_team);
 
-  if (!teamId) {
-    return res.status(400).json({ error: "teamId missing" });
-  }
-
-  try {
-    const teenager = await Teenager.findById(req.params.id)
-    if (!teenager) {
-      return res.status(404).json({ error: "teenager not found" });
-    }
-    
-    // update the teenager's teamId
-    teenager.teamId = teamId;
-
-    const savedTeenager = await teenager.save();
-    return res.json(savedTeenager);
-  } catch (err) {
-    console.error(err);
-    return res.status(500).json({ error: "internal server error" });
-  }
-});
-
-router.post("/", (req, res) => {
-  const body = req.body;
-
-  if (!body) {
-    return res.status(400).json({ error: "content missing" });
-  }
-
-  const teenager = new Teenager({
-    name: body.name,
-    dateOfBirth: new Date(body.dateOfBirth),
-    email: body.email,
-    password: body.password,
-    teamId: body.teamId,
-  });
-
-  let error = teenager.validateSync();
-  if (error) {
-    return res.status(400).json(error);
-  }
-
-  return teenager.save().then((savedTeenager) => {
-    return res.json(savedTeenager);
-  });
-});
+router.post("/", create_teenager);
 
 export default router;

--- a/server/src/services/child_service.test.ts
+++ b/server/src/services/child_service.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test, jest } from "@jest/globals";
+
+import {
+  create_child,
+  get_all_children,
+  get_child_by_id,
+  update_child_team,
+} from "./child_service";
+
+describe("child controller", () => {
+  test("get all children", async () => {
+    const req = {} as any;
+
+    const mock_json = jest.fn();
+
+    const res = {
+      json: mock_json,
+    } as any;
+
+    await get_all_children(req, res);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("get a child by id", async () => {
+    const req = {
+      params: {
+        id: "68f902e22c24602e73bfb19d" as String,
+      },
+    } as any;
+
+    const mock_json = jest.fn();
+
+    const res = {
+      json: mock_json,
+    } as any;
+
+    await get_child_by_id(req, res);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("create child (valid)", async () => {
+    const req = {
+      body: {
+        name: "Little Tim",
+        dateOfBirth: "2015-03-15",
+        guardianId: "guardian-1",
+        teamId: "team-9",
+      },
+    } as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn();
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await create_child(req, res);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("create child with missing body returns 400", async () => {
+    const req = {} as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn().mockReturnValue({ json: mock_json });
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await create_child(req, res);
+    expect(mock_status).toHaveBeenCalledWith(400);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("create child missing required field returns 400", async () => {
+    const req = {
+      body: {
+        // name missing
+        dateOfBirth: "2012-01-01",
+        guardianId: "guardian-1",
+        teamId: "team-9",
+      },
+    } as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn().mockReturnValue({ json: mock_json });
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await create_child(req, res);
+    expect(mock_status).toHaveBeenCalledWith(400);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("create child with invalid date returns 400", async () => {
+    const req = {
+      body: {
+        name: "Invalid Date Child",
+        dateOfBirth: "not-a-date",
+        guardianId: "guardian-1",
+        teamId: "team-9",
+      },
+    } as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn().mockReturnValue({ json: mock_json });
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await create_child(req, res);
+    expect(mock_status).toHaveBeenCalledWith(400);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("patch child team - missing teamId returns 400", async () => {
+    const req = {
+      params: { id: "child-1" },
+      body: {},
+    } as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn().mockReturnValue({ json: mock_json });
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await update_child_team(req, res);
+    expect(mock_status).toHaveBeenCalledWith(400);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("patch child team - not found returns 404", async () => {
+    const req = {
+      params: { id: "does-not-exist" },
+      body: { teamId: "team-77" },
+    } as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn().mockReturnValue({ json: mock_json });
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await update_child_team(req, res);
+    // Depending on db state, could throw. We only assert that status was called with 404 or 500
+    const statusCalledWith = (mock_status.mock.calls[0] ?? [])[0];
+    expect([404, 500]).toContain(statusCalledWith);
+    expect(mock_json).toHaveBeenCalled();
+  });
+});

--- a/server/src/services/child_service.ts
+++ b/server/src/services/child_service.ts
@@ -1,0 +1,61 @@
+import Child from "../models/children";
+import { Request, Response } from "express";
+
+export const get_all_children = async (_req: Request, res: Response) => {
+  return Child.find({}).then((result) => {
+    return res.json(result);
+  });
+};
+
+export const get_child_by_id = async (req: Request, res: Response) => {
+  return Child.findById(req.params.id).then((child) => {
+    return res.json(child);
+  });
+};
+
+export const create_child = (req: Request, res: Response) => {
+  const body = req.body;
+
+  if (!body) {
+    return res.status(400).json({ error: "content missing" });
+  }
+
+  const child = new Child({
+    name: body.name,
+    dateOfBirth: new Date(body.dateOfBirth),
+    guardianId: body.guardianId,
+    teamId: body.teamId,
+  });
+
+  let error = child.validateSync();
+  if (error) {
+    return res.status(400).json(error);
+  }
+
+  return child.save().then((savedChild) => {
+    return res.json(savedChild);
+  });
+};
+
+export const update_child_team = async (req: Request, res: Response) => {
+  const { teamId } = req.body ?? {};
+
+  if (!teamId) {
+    return res.status(400).json({ error: "teamId missing" });
+  }
+
+  try {
+    const child = await Child.findById(req.params.id);
+    if (!child) {
+      return res.status(404).json({ error: "child not found" });
+    }
+
+    child.teamId = teamId;
+
+    const savedChild = await child.save();
+    return res.json(savedChild);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "internal server error" });
+  }
+};

--- a/server/src/services/guardian_service.test.ts
+++ b/server/src/services/guardian_service.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test, jest, beforeEach } from "@jest/globals";
+import Guardian from "../models/guardians";
+
+import {
+  create_guardian,
+  get_all_guardians,
+  get_guardian_by_id,
+} from "./guardian_service";
+
+describe("guardian controller", () => {
+  beforeEach(async () => {
+    await Guardian.deleteMany({});
+  });
+
+  test("get all guardians", async () => {
+    const req = {} as any;
+
+    const mock_json = jest.fn();
+
+    const res = {
+      json: mock_json,
+    } as any;
+
+    await get_all_guardians(req, res);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("get a guardian by id", async () => {
+    const req = {
+      params: {
+        id: "68f902e22c24602e73bfb19d" as String,
+      },
+    } as any;
+
+    const mock_json = jest.fn();
+
+    const res = {
+      json: mock_json,
+    } as any;
+
+    await get_guardian_by_id(req, res);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("create guardian (valid)", async () => {
+    const req = {
+      body: {
+        name: "Jane Doe",
+        dateOfBirth: "1980-05-20",
+        email: "jane.doe@example.com",
+        password: "supersecret",
+        childId: "child-123",
+      },
+    } as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn();
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await create_guardian(req, res);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("create guardian with missing body returns 400", async () => {
+    const req = {} as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn().mockReturnValue({ json: mock_json });
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await create_guardian(req, res);
+    expect(mock_status).toHaveBeenCalledWith(400);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("create guardian missing required field returns 400", async () => {
+    const req = {
+      body: {
+        // name missing
+        dateOfBirth: "1980-05-20",
+        email: "missing.name@example.com",
+        password: "pw",
+        childId: "child-123",
+      },
+    } as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn().mockReturnValue({ json: mock_json });
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await create_guardian(req, res);
+    expect(mock_status).toHaveBeenCalledWith(400);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("create guardian with invalid date returns 400", async () => {
+    const req = {
+      body: {
+        name: "Invalid Date",
+        dateOfBirth: "not-a-date",
+        email: "invalid.date@example.com",
+        password: "pw",
+        childId: "child-123",
+      },
+    } as any;
+
+    const mock_json = jest.fn();
+    const mock_status = jest.fn().mockReturnValue({ json: mock_json });
+
+    const res = {
+      json: mock_json,
+      status: mock_status,
+    } as any;
+
+    await create_guardian(req, res);
+    expect(mock_status).toHaveBeenCalledWith(400);
+    expect(mock_json).toHaveBeenCalled();
+  });
+});

--- a/server/src/services/guardian_service.ts
+++ b/server/src/services/guardian_service.ts
@@ -1,0 +1,39 @@
+import Guardian from "../models/guardians";
+import { Request, Response } from "express";
+
+export const get_all_guardians = async (_req: Request, res: Response) => {
+  return Guardian.find({}).then((result) => {
+    return res.json(result);
+  });
+};
+
+export const get_guardian_by_id = async (req: Request, res: Response) => {
+  return Guardian.findById(req.params.id).then((guardian) => {
+    return res.json(guardian);
+  });
+};
+
+export const create_guardian = (req: Request, res: Response) => {
+  const body = req.body;
+
+  if (!body) {
+    return res.status(400).json({ error: "content missing" });
+  }
+
+  const guardian = new Guardian({
+    name: body.name,
+    dateOfBirth: new Date(body.dateOfBirth),
+    email: body.email,
+    password: body.password,
+    childId: body.childId,
+  });
+
+  let error = guardian.validateSync();
+  if (error) {
+    return res.status(400).json(error);
+  }
+
+  return guardian.save().then((savedGuardian) => {
+    return res.json(savedGuardian);
+  });
+};

--- a/server/src/services/teenager_service.ts
+++ b/server/src/services/teenager_service.ts
@@ -1,0 +1,62 @@
+import Teenager from "../models/teenagers";
+import { Request, Response } from "express";
+
+export const get_all_teenagers = async (_req: Request, res: Response) => {
+  return Teenager.find({}).then((result) => {
+    return res.json(result);
+  });
+};
+
+export const get_teenager_by_id = async (req: Request, res: Response) => {
+  return Teenager.findById(req.params.id).then((teenager) => {
+    return res.json(teenager);
+  });
+};
+
+export const create_teenager = (req: Request, res: Response) => {
+  const body = req.body;
+
+  if (!body) {
+    return res.status(400).json({ error: "content missing" });
+  }
+
+  const teenager = new Teenager({
+    name: body.name,
+    dateOfBirth: new Date(body.dateOfBirth),
+    email: body.email,
+    password: body.password,
+    teamId: body.teamId,
+  });
+
+  let error = teenager.validateSync();
+  if (error) {
+    return res.status(400).json(error);
+  }
+
+  return teenager.save().then((savedTeenager) => {
+    return res.json(savedTeenager);
+  });
+};
+
+export const update_teenager_team = async (req: Request, res: Response) => {
+  const { teamId } = req.body ?? {};
+
+  if (!teamId) {
+    return res.status(400).json({ error: "teamId missing" });
+  }
+
+  try {
+    const teenager = await Teenager.findById(req.params.id);
+    if (!teenager) {
+      return res.status(404).json({ error: "teenager not found" });
+    }
+
+    teenager.teamId = teamId;
+
+    const savedTeenager = await teenager.save();
+    return res.json(savedTeenager);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "internal server error" });
+  }
+};

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -11,7 +11,7 @@ export interface IGuardian {
   dateOfBirth: Date; // guardian date of birth
   email: String; // guardian email
   password: String; // guardian password
-  childId: String; // id of child, TODO: add multiple children support
+  childId?: String; // id of child, TODO: add multiple children support
 }
 
 export interface IChild {


### PR DESCRIPTION
I created child_service.ts, guardian_service.ts, and teenager_service.ts, and added unit tests for the child and guardian services. The guardian_router.ts and teenager_router.ts were refactored to delegate business logic to the new services, and types.ts and models/guardians.ts were updated to align with the new structure.