### PR TITLE
Add get_team_players endpoint with tests and error handling

### DIFF
--- a/server/src/controllers/team_controller.test.ts
+++ b/server/src/controllers/team_controller.test.ts
@@ -5,7 +5,9 @@ import {
   get_all_teams,
   get_team_by_id,
   update_team_players,
+  get_team_players,
 } from "./team_controller";
+import Team from "../models/teams";
 
 describe("team controller", () => {
   let mock_json: jest.Mock;
@@ -85,6 +87,47 @@ describe("team controller", () => {
 
     await update_team_players(req, res);
 
+    expect(mock_status).toHaveBeenCalledWith(500);
+    expect(mock_json).toHaveBeenCalledWith({ error: "internal server error" });
+  });
+
+  test("get team players", async () => {
+    const req = {
+      params: {
+        id: "68f902e22c24602e73bfb19d" as String,
+      },
+    } as any;
+
+    await get_team_players(req, res);
+    expect(mock_json).toHaveBeenCalled();
+  });
+
+  test("get team players - team not found returns 404", async () => {
+    jest.spyOn(Team as any, "findById").mockResolvedValue(null as any);
+
+    const req = {
+      params: {
+        id: "does-not-exist" as String,
+      },
+    } as any;
+
+    await get_team_players(req, res);
+    expect(mock_status).toHaveBeenCalledWith(404);
+    expect(mock_json).toHaveBeenCalledWith({ error: "team not found" });
+  });
+
+  test("get team players - internal error returns 500", async () => {
+    jest
+      .spyOn(Team as any, "findById")
+      .mockRejectedValue(new Error("db error"));
+
+    const req = {
+      params: {
+        id: "err" as String,
+      },
+    } as any;
+
+    await get_team_players(req, res);
     expect(mock_status).toHaveBeenCalledWith(500);
     expect(mock_json).toHaveBeenCalledWith({ error: "internal server error" });
   });

--- a/server/src/controllers/team_controller.ts
+++ b/server/src/controllers/team_controller.ts
@@ -1,4 +1,6 @@
 import Team from "../models/teams";
+import Child from "../models/children";
+import Teenager from "../models/teenagers";
 import { Request, Response } from "express";
 
 export const get_all_teams = async (_req: Request, res: Response) => {
@@ -59,6 +61,31 @@ export const update_team_players = async (req: Request, res: Response) => {
 
     const savedTeam = await team.save();
     return res.json(savedTeam);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "internal server error" });
+  }
+};
+
+export const get_team_players = async (req: Request, res: Response) => {
+  try {
+    const team = await Team.findById(req.params.id);
+    if (!team) {
+      return res.status(404).json({ error: "team not found" });
+    }
+
+    const teamId = (team as any)._id?.toString();
+    if (!teamId) {
+      return res.status(500).json({ error: "invalid team id" });
+    }
+
+    if (team.is_teen_team) {
+      const players = await Teenager.find({ teamId });
+      return res.json(players);
+    } else {
+      const players = await Child.find({ teamId });
+      return res.json(players);
+    }
   } catch (err) {
     console.error(err);
     return res.status(500).json({ error: "internal server error" });

--- a/server/src/routes/team_router.ts
+++ b/server/src/routes/team_router.ts
@@ -4,6 +4,7 @@ import {
   get_all_teams,
   get_team_by_id,
   update_team_players,
+  get_team_players,
 } from "../controllers/team_controller";
 
 const router = express.Router();
@@ -11,6 +12,8 @@ const router = express.Router();
 router.get("/", get_all_teams);
 
 router.get("/:id", get_team_by_id);
+
+router.get("/:id/players", get_team_players);
 
 router.patch("/:id", update_team_players);
 


### PR DESCRIPTION
This PR adds the backend implementation for the get_team_players endpoint, including logic to retrieve players by team ID and unit tests for proper error handling and responses. 

NOTE: this only includes the backend; the frontend will be implemented in the next sprint.